### PR TITLE
Implement route pattern params using URLPattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 23.x, 24.x]
+        node-version: [24.x, 25.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ server.useMiddleware((data) => {
 
   - Return `this` so it can be chained.
   - `RequestResult` is optional.
+  - Routes are matched using `URLPattern`, supporting static paths and parameterized routes (e.g., `/echo/:id`).
+  - Route precedence follows LIFO (Last In, First Out): the most recently added matching route is selected.
 
 - `RequestResult`
 
@@ -92,6 +94,7 @@ server.useMiddleware((data) => {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'...;
     headers: object;
     payload?: string; // May be undefined if no body was sent
+    groups?: object; // Optional URL pattern groups from route matching
   }
   ```
 - Middlewares are called FIFO, and called before any handler.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yahf",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yahf",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "engines": {
         "node": ">= 22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yahf",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Yet Another HTTP Framework, that you don't really need",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": ">= 22"
+    "node": ">= 24"
   },
   "scripts": {
-    "test": "node --test"
+    "test": "node --test --experimental-test-coverage"
   },
   "author": "Assaf Sapir <me@ass.af>",
   "license": "MIT",

--- a/tests/yahf.test.js
+++ b/tests/yahf.test.js
@@ -73,6 +73,56 @@ describe("YAHF", () => {
     );
   });
 
+  it("Handles POST with middleware and controller (case insensitive)", async () => {
+    const port = getRandomPort();
+    const server = createServer(port)
+      .useMiddleware((data) => {
+        data.payload = `${data.headers["user-agent"]} and ${data.method}`;
+      })
+      .addHandler({
+        path: "echo",
+        method: "post",
+        handler: async (data) => {
+          return {
+            statusCode: 201,
+            payload: data.payload,
+            contentType: "text/plain",
+            headers: {
+              "oh-no": "this is a test",
+            },
+          };
+        },
+      });
+    await server.start();
+    const res = await requestYahf("POST", "/echo", port);
+    await server.kill();
+
+    const body = await res.text();
+
+    assert.strictEqual(
+      res.status,
+      201,
+      `status code suppose to be 201, but was ${res.status}`
+    );
+    assert.strictEqual(
+      res.headers.get("content-type"),
+      "text/plain",
+      `content-type suppose to be text/plain, but it ${
+        res.headers[`content-type`]
+      }`
+    );
+    assert.strictEqual(
+      body,
+      "YAHF/0.1.1 and POST",
+      `body should have been YAHF/0.1.1, but it was ${body}`
+    );
+    assert.strictEqual(
+      res.headers.get("oh-no"),
+      "this is a test",
+      `headers should have been set to {'oh-no':'this is a test'}`
+    );
+  });
+
   it("Returns 404 for different methods", async () => {
     const port = getRandomPort();
     const server = createServer(port).addHandler({
@@ -121,6 +171,205 @@ describe("YAHF", () => {
     const res = await requestYahf("POST", "/echo", port, null);
     await server.kill();
     const body = await res.text();
-    assert.equal(body, "", `body should have been empty, but it was ${body}`);
+    assert.strictEqual(
+      body,
+      "",
+      `body should have been empty, but it was ${body}`
+    );
+  });
+
+  it("Handles url pattern", async () => {
+    const port = getRandomPort();
+    const server = createServer(port).addHandler({
+      path: "echo/:id",
+      method: "post",
+      handler: async (data) => {
+        return {
+          statusCode: 201,
+          payload: data.groups.id,
+          contentType: "text/plain",
+        };
+      },
+    });
+    await server.start();
+    const res = await requestYahf("POST", "/echo/123", port);
+    await server.kill();
+
+    const body = await res.text();
+
+    assert.strictEqual(
+      res.status,
+      201,
+      `status code suppose to be 201, but was ${res.status}`
+    );
+    assert.strictEqual(
+      res.headers.get("content-type"),
+      "text/plain",
+      `content-type suppose to be text/plain, but it ${
+        res.headers[`content-type`]
+      }`
+    );
+    assert.strictEqual(
+      body,
+      "123",
+      `body should have been 123, but it was ${body}`
+    );
+  });
+
+  it("Accumulates request payload and passes it to handler", async () => {
+    const port = getRandomPort();
+    const server = createServer(port).addHandler({
+      path: "body",
+      method: "POST",
+      handler: async (data) => {
+        return {
+          payload: data.payload,
+        };
+      },
+    });
+
+    await server.start();
+    const res = await requestYahf("POST", "/body", port, { hello: "world" });
+    await server.kill();
+
+    const jsonResponse = await res.json();
+    assert.equal(
+      res.status,
+      200,
+      `status code suppose to be 200, but was ${res.status}`
+    );
+    assert.equal(
+      res.headers.get("content-type"),
+      "application/json",
+      `content-type suppose to be JSON, but it ${res.headers[`content-type`]}`
+    );
+    assert.deepEqual(
+      jsonResponse,
+      { hello: "world" },
+      `response body suppose to be { hello: 'world' }, but was ${jsonResponse}`
+    );
+  });
+
+  it("Responds with 500 when a middleware throws", async () => {
+    const port = getRandomPort();
+    const server = createServer(port)
+      .useMiddleware(() => {
+        throw new Error("boom");
+      })
+      .addHandler({
+        path: "any",
+        method: "GET",
+        handler: async () => ({ payload: "should not reach" }),
+      });
+
+    await server.start();
+    const res = await requestYahf("GET", "/any", port);
+    await server.kill();
+
+    const text = await res.text();
+    assert.equal(
+      res.status,
+      500,
+      `status code suppose to be 500, but was ${res.status}`
+    );
+    assert.equal(
+      text,
+      "boom",
+      `error message should be 'boom', but was ${text}`
+    );
+  });
+
+  it("Responds with 500 when a handler throws", async () => {
+    const port = getRandomPort();
+    const server = createServer(port).addHandler({
+      path: "boom",
+      method: "GET",
+      handler: async () => {
+        throw new Error("kaboom");
+      },
+    });
+
+    await server.start();
+    const res = await requestYahf("GET", "/boom", port);
+    await server.kill();
+
+    const text = await res.text();
+    assert.equal(
+      res.status,
+      500,
+      `status code suppose to be 500, but was ${res.status}`
+    );
+    assert.equal(
+      text,
+      "kaboom",
+      `error message should be 'kaboom', but was ${text}`
+    );
+  });
+
+  it("kill() rejects if server is not running", async () => {
+    const server = new YAHF();
+    await assert.rejects(() => server.kill());
+  });
+
+  it("Exposes the configured logger via getter", () => {
+    const logger = () => {};
+    const server = new YAHF({ port: getRandomPort(), logger });
+    assert.strictEqual(
+      server.logger,
+      logger,
+      "logger getter should return the configured logger"
+    );
+  });
+
+  describe("Routing precedence (LIFO)", () => {
+    it("static route added after param route should match first", async () => {
+      const port = getRandomPort();
+      const server = createServer(port)
+        .addHandler({
+          path: "echo/:id",
+          method: "GET",
+          handler: async () => ({ payload: "param" }),
+        })
+        .addHandler({
+          path: "echo/static",
+          method: "GET",
+          handler: async () => ({ payload: "static" }),
+        });
+
+      await server.start();
+      const res = await requestYahf("GET", "/echo/static", port);
+      await server.kill();
+
+      const body = await res.text();
+      assert.equal(res.status, 200);
+      assert.equal(body, "static", `LIFO should pick 'static', got ${body}`);
+    });
+
+    it("param route added after static route should match first", async () => {
+      const port = getRandomPort();
+      const server = createServer(port)
+        .addHandler({
+          path: "echo/static",
+          method: "GET",
+          handler: async () => ({ payload: "static" }),
+        })
+        .addHandler({
+          path: "echo/:id",
+          method: "GET",
+          handler: async (data) => ({ payload: `param:${data.groups.id}` }),
+        });
+
+      await server.start();
+      const res = await requestYahf("GET", "/echo/static", port);
+      await server.kill();
+
+      const body = await res.text();
+      assert.equal(res.status, 200);
+      assert.equal(
+        body,
+        "param:static",
+        `LIFO should pick param route, got ${body}`
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR implements route pattern params using URLPattern as requested in issue #4.

## Changes Made

- Updated routing system to use `URLPattern` for matching routes
- Added support for parameterized routes like `/echo/:id`
- Modified `addHandler` to store routes by method and use URLPattern
- Updated request data to include `groups` from URLPattern matches
- Added comprehensive tests for URL pattern matching and routing precedence
- Updated documentation in README.md
- Updated CI to test on Node.js 24.x and 25.x
- Added test coverage reporting

## Key Features

- Routes support parameters via `:param` syntax
- Case insensitive matching
- LIFO precedence for route matching
- Groups from URLPattern are passed to handlers as `data.groups`

Closes #4