### PR TITLE
feat: use Web Headers API for request and response headers; add examples and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,23 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm test
+
+  examples:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [24.x, 25.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run examples and validate
+        run: |
+          set -e
+          npm run examples

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ server.useMiddleware((data) => {
     statusCode?: number; // Defaults to 200
     contentType?: string; // Defaults to 'application/json'
     payload?: any;
-    headers?: object; // Optional headers to set on the response
+    headers?: Headers|object; // Optional response headers as either a Web `Headers` instance or a plain object. Object values may be strings or arrays of strings for multiple header values.
   }
   ```
 
@@ -134,6 +134,35 @@ const server = new YAHF()
   });
 
 server.start();
+
+### Example scripts
+
+There are ready-made examples in the `examples/` directory which also run as part of CI. Run them locally and call them with curl to see responses. To run all examples locally and validate them automatically, use the `examples` npm script (it will start every `*.js` example on consecutive ports starting at 1338):
+
+```bash
+# run all examples and validate
+npm run examples
+```
+
+- Run the echo example (POST /echo):
+
+```bash
+# start the example server on port 1338
+PORT=1338 node examples/echo.js
+
+# in another terminal, call it with curl
+curl -s -X POST -H "Content-Type: application/json" -d '{"hello":"world"}' http://localhost:1338/echo
+```
+
+- Run the headers example (GET /headers) which demonstrates returning a `Headers` instance from a handler:
+
+```bash
+# start the headers example on port 1339
+PORT=1339 node examples/headers.js
+
+# use curl to fetch a response and show headers
+curl -sI http://localhost:1339/headers
+```
 ```
 
 ## Built-in Middleware
@@ -180,7 +209,7 @@ server.addHandler({
     path: string;
     query: URLSearchParams;
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'...;
-    headers: object;
+    headers: Headers|object;
     payload?: any; // Parsed request body (JSON object, text string, or undefined)
     groups?: object; // Optional URL pattern groups from route matching
   }

--- a/examples/echo.js
+++ b/examples/echo.js
@@ -1,6 +1,7 @@
 import YAHF from "../src/yahf.js";
 
-const server = new YAHF().addHandler({
+const port = Number(process.env.PORT ?? 1337);
+const server = new YAHF({ port }).addHandler({
   path: "echo",
   method: "POST",
   handler: async (data) => {
@@ -11,3 +12,4 @@ const server = new YAHF().addHandler({
 });
 
 server.start();
+console.log(`Example echo server started on port ${port}`);

--- a/examples/headers.js
+++ b/examples/headers.js
@@ -1,0 +1,19 @@
+import YAHF from "../src/yahf.js";
+
+const port = Number(process.env.PORT ?? 1338);
+
+const server = new YAHF({ port }).addHandler({
+  path: "headers",
+  method: "GET",
+  handler: async () => {
+    return {
+      statusCode: 200,
+      payload: "ok",
+      contentType: "text/plain",
+      headers: new Headers({ "x-example": "hello" }),
+    };
+  },
+});
+
+server.start();
+console.log(`Example headers server started on port ${port}`);

--- a/examples/runExamples.js
+++ b/examples/runExamples.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { setTimeout } from "node:timers/promises";
+
+const examplesDir = path.resolve(new URL(import.meta.url).pathname, "..");
+const files = fs
+  .readdirSync(examplesDir)
+  .filter((f) => f.endsWith(".js") && f !== "runExamples.js");
+
+const START_PORT = Number(process.env.START_PORT ?? 1338);
+
+const processes = [];
+
+async function waitForServer(port, route = "/", timeout = 1000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(`http://localhost:${port}${route}`, {
+        method: "GET",
+      });
+      if (res) return true;
+    } catch (err) {
+      // ignore, server not up yet
+    }
+    await setTimeout(500);
+  }
+  return false;
+}
+
+async function run() {
+  if (!files.length) {
+    console.log("No examples found");
+    return;
+  }
+
+  let i = 0;
+  for (const file of files) {
+    const port = START_PORT + i;
+    const fpath = path.join(examplesDir, file);
+    console.log(`Starting ${file} on port ${port}...`);
+    const child = spawn("node", [fpath], {
+      env: { ...process.env, PORT: `${port}` },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout.on("data", (d) => process.stdout.write(`[${file}] ${d}`));
+    child.stderr.on("data", (d) => process.stderr.write(`[${file}] ${d}`));
+
+    processes.push(child);
+    i++;
+  }
+
+  try {
+    // Inspect each example file to discover the route path and method
+    for (let j = 0; j < files.length; j++) {
+      const file = files[j];
+      const content = fs.readFileSync(path.join(examplesDir, file), "utf8");
+      const pathMatch = content.match(/path:\s*["']([^"']+)["']/);
+      const methodMatch = content.match(/method:\s*["']([^"']+)["']/i);
+      const route = pathMatch ? `/${pathMatch[1]}` : "/";
+      const method = methodMatch ? methodMatch[1].toUpperCase() : "GET";
+      const port = START_PORT + j;
+      console.log(`Validating ${file} (${method} ${route}) at port ${port}`);
+
+      // wait for the server to respond on its main route
+      const up = await waitForServer(port, route);
+      if (!up) throw new Error(`${file} ${route} did not respond in time`);
+
+      if (method === "POST") {
+        const res = await fetch(`http://localhost:${port}${route}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ hello: "ci" }),
+        });
+        if (!res.ok) throw new Error(`${file} ${route} returned ${res.status}`);
+      } else {
+        const res = await fetch(`http://localhost:${port}${route}`, {
+          method: "GET",
+        });
+        if (!res) throw new Error(`${file} ${route} did not respond`);
+        // If the example exposes a /headers endpoint, check for header presence
+        if (route.toLowerCase().includes("headers")) {
+          const headerValue = res.headers.get("x-example");
+          if (!headerValue)
+            throw new Error(`${file} ${route} missed x-example header`);
+        }
+      }
+    }
+    // Completed checks – exit normally
+
+    console.log("All examples started successfully.");
+  } catch (err) {
+    console.error("Error starting examples:", err.message);
+    process.exitCode = 1;
+  } finally {
+    // kill children
+    for (const p of processes) p.kill();
+  }
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": ">= 24"
   },
   "scripts": {
-    "test": "node --test --experimental-test-coverage"
+    "test": "node --test --experimental-test-coverage",
+    "examples": "node examples/runExamples.js"
   },
   "author": "Assaf Sapir <assaf@sapir.io>",
   "license": "MIT",

--- a/src/middlewares/bodyParser.js
+++ b/src/middlewares/bodyParser.js
@@ -27,7 +27,7 @@ export class BodyParser {
    * @private
    */
   #parse(data) {
-    const contentType = data.headers["content-type"] || "plain/text";
+    const contentType = data.headers?.get("content-type") || "plain/text";
     switch (contentType) {
       // case "multipart/form-data":
       //   return this.#parseFormData(data);


### PR DESCRIPTION
This PR converts incoming request headers into a Web `Headers` instance, updates the BodyParser and middleware expectations to use `Headers.get`, allows handler responses to return either a `Headers` instance or a plain object (string or array values), and adds example scripts and CI validation.

Summary of changes:
- Convert incoming headers to `Headers` in `src/yahf.js` (#buildHeadersFromRaw)
- Add `#applyResponseHeaders` to stream response headers from `Headers` or object
- Update `BodyParser` to use `data.headers.get` for content-type
- Update tests to use `.get()` and add tests for object headers and multi-values
- Add examples `examples/headers.js` and `examples/echo.js` that can be validated
- Add `examples/runExamples.js` and `npm run examples` to validate examples in CI
- Update README and CI workflow to run examples in Node 24/25

This is a non-breaking change for existing handlers that return plain object headers; middleware should use `data.headers.get` now.

Please review.
