### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Continuous Integration
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/assapir/yahf/security/code-scanning/2](https://github.com/assapir/yahf/security/code-scanning/2)

To fix the problem, add a `permissions` block specifying the lowest privileges required. In this workflow, both jobs (build and examples) are simply checking out source code and running tests and examples. They do not appear to require writing to the repository, modifying pull requests, or making releases. Therefore, it is sufficient and prudent to limit GITHUB_TOKEN permissions to `contents: read`. The recommended way is to add the following at the root of the workflow file (before the `jobs:` block), ensuring all jobs inherit these minimal permissions. No changes to imports, methods, or existing workflow functionality are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
