### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/assapir/yahf/security/code-scanning/3](https://github.com/assapir/yahf/security/code-scanning/3)

To fix this issue, we should add a `permissions` block to the workflow. The best way to do this is to set it at the root level of the workflow file, so the permissions apply to all jobs unless overridden. Based on the jobs shown ("build" and "examples"), the minimum needed is read access to repository contents since both jobs only seem to check out code and run tests or examples—no publishing, no writing to issues, or other writing operations. Edit the file `.github/workflows/ci.yml` and insert the following block after the workflow `name` and before the `on` key:
```yaml
permissions:
  contents: read
```
No imports, function definitions, or broader changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
